### PR TITLE
feat: add configurable fetch_example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project demonstrates how to fetch data from the web using Python's `request
 
 ## Features
 
-- Simple `fetch_example` function that retrieves a snippet from [example.com](https://example.com).
+- Simple `fetch_example` function that retrieves a snippet from a specified URL (defaults to [example.com](https://example.com)) with a configurable character limit.
 - Lightweight structure with a single dependency.
 
 ## Usage
@@ -14,6 +14,8 @@ Run the main script to display the first 100 characters returned by the site:
 ```bash
 python src/main.py
 ```
+
+You can customize the URL and the length of the returned snippet by passing arguments to `fetch_example` in `src/main.py`.
 
 ## Installation
 

--- a/src/main.py
+++ b/src/main.py
@@ -2,16 +2,30 @@ import requests
 import requests.exceptions
 
 
-def fetch_example():
-    """Fetch a snippet from example.com to demonstrate a dependency."""
+def fetch_example(url: str = "https://example.com", limit: int = 100) -> str:
+    """Fetch a snippet from the specified URL.
+
+    Args:
+        url: Web address to retrieve.
+        limit: Maximum number of characters to return from the response body.
+
+    Returns:
+        A substring of the response body or an error message.
+
+    Raises:
+        ValueError: If ``limit`` is not a positive integer.
+    """
+    if limit <= 0:
+        raise ValueError("limit must be positive")
+
     try:
-        response = requests.get("https://example.com", timeout=10)
+        response = requests.get(url, timeout=10)
     except requests.exceptions.RequestException as exc:
         return f"Error fetching data: {exc}"
     if response.ok:
-        return response.text[:100]
+        return response.text[:limit]
     return "Error fetching data"
 
 
 if __name__ == "__main__":
-    print(fetch_example())
+    print(fetch_example(url="https://example.com", limit=100))


### PR DESCRIPTION
## Summary
- allow `fetch_example` to accept customizable URL and response length
- validate `limit` parameter to be positive
- document new flexibility in README

## Testing
- `python src/main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8055f108c8326abf6d8334a59138a