### PR TITLE
Add fetch_example tests and testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,12 @@ Install the required dependency listed in [requirements.txt](requirements.txt). 
 pip install -r requirements.txt
 ```
 
+
+## Tests
+
+Install the test dependencies and run the suite with:
+
+```bash
+pip install -r requirements.txt pytest requests-mock
+pytest
+```

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,32 @@
+import pathlib
+import sys
+
+import pytest
+import requests
+import requests.exceptions
+
+# Ensure the src directory is on the path for imports
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from main import fetch_example
+
+
+def test_fetch_example_success(requests_mock):
+    requests_mock.get("https://example.com", text="Example Domain", status_code=200)
+    assert fetch_example("https://example.com", limit=7) == "Example"
+
+
+def test_fetch_example_http_error(requests_mock):
+    requests_mock.get("https://example.com", status_code=404)
+    assert fetch_example("https://example.com") == "Error fetching data"
+
+
+def test_fetch_example_exception(requests_mock):
+    requests_mock.get("https://example.com", exc=requests.exceptions.Timeout)
+    result = fetch_example("https://example.com")
+    assert result.startswith("Error fetching data:")
+
+
+def test_fetch_example_invalid_limit():
+    with pytest.raises(ValueError):
+        fetch_example(limit=0)


### PR DESCRIPTION
## Summary
- add pytest suite with requests-mock covering success, error, exception, and invalid input cases
- document how to install test dependencies and run tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8320499c883269a9d80a56dfe701c