### PR TITLE
Add pyproject configuration and pip install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,21 @@ You can customize the URL and the length of the returned snippet by passing argu
 
 ## Installation
 
-Install the required dependency listed in [requirements.txt](requirements.txt). For a step-by-step setup guide, including how to use a virtual environment, see [INSTALL.md](INSTALL.md):
+Install the project and its dependencies with:
+
+```bash
+pip install .
+```
+
+This will provide the CLI command `ollama-crewai`.
+
+Alternatively, install the required dependency listed in [requirements.txt](requirements.txt):
 
 ```bash
 pip install -r requirements.txt
 ```
 
+For a step-by-step setup guide, including how to use a virtual environment, see [INSTALL.md](INSTALL.md).
 
 ## Tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ollama-crewai"
+version = "0.1.0"
+dependencies = [
+    "requests>=2.31.0",
+]
+
+[project.scripts]
+ollama-crewai = "main:main"
+
+[tool.setuptools]
+py-modules = ["main"]
+package-dir = {"" = "src"}


### PR DESCRIPTION
## Summary
- define package metadata and CLI entrypoint in `pyproject.toml`
- document installation using `pip install .`

## Testing
- `pip install .`
- `pip install pytest requests-mock`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a834c199a48326ac2f0a0ee09646f8