### PR TITLE
feat: add configurable timeout and retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project demonstrates how to fetch data from the web using Python's `request
 
 ## Features
 
-- Simple `fetch_example` function that retrieves a snippet from a specified URL (defaults to [example.com](https://example.com)) with a configurable character limit.
+- Simple `fetch_example` function that retrieves a snippet from a specified URL (defaults to [example.com](https://example.com)) with configurable character limit, timeout, and retry behavior.
 - Lightweight structure with a single dependency.
 
 ## Usage
@@ -15,7 +15,7 @@ Run the main script to display the first 100 characters returned by the site:
 python src/main.py
 ```
 
-You can customize the URL and the length of the returned snippet by passing arguments to `fetch_example` in `src/main.py`.
+You can customize the URL, length of the returned snippet, request timeout, and number of retries by passing arguments to `fetch_example` in `src/main.py`.
 
 ## Installation
 
@@ -48,10 +48,12 @@ pytest
 
 ### Environment variables
 
-The script honors two optional environment variables:
+The script honors several optional environment variables:
 
 - `FETCH_URL`: URL to fetch (defaults to `https://example.com`).
 - `FETCH_LIMIT`: Number of characters to display (defaults to `100`).
+- `FETCH_TIMEOUT`: Timeout in seconds for the request (defaults to `10`).
+- `FETCH_RETRIES`: Number of retry attempts for failed requests (defaults to `0`).
 
 You can set them inline when invoking the CLI:
 
@@ -70,7 +72,6 @@ python src/main.py
 ## Possible extensions
 
 - Accept command-line arguments for URL and character limit.
-- Add retries or adjustable timeouts.
 - Integrate asynchronous fetching or caching mechanisms.
 
 ## Contributing

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,8 @@ import sys
 import pytest
 import requests
 import requests.exceptions
+from requests.adapters import HTTPAdapter
+from urllib3.util import Retry
 
 # Ensure the src directory is on the path for imports
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
@@ -37,3 +39,38 @@ def test_fetch_example_env_vars(requests_mock, monkeypatch):
     monkeypatch.setenv("FETCH_URL", "https://example.org")
     monkeypatch.setenv("FETCH_LIMIT", "7")
     assert fetch_example() == "Example"
+
+
+def test_fetch_example_retries_adapter(requests_mock, monkeypatch):
+    requests_mock.get("https://example.com", text="Example Domain", status_code=200)
+
+    created: dict[str, Retry] = {}
+    original_init = HTTPAdapter.__init__
+
+    def fake_init(self, *args, **kwargs):  # type: ignore[override]
+        created["max_retries"] = kwargs.get("max_retries")
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(HTTPAdapter, "__init__", fake_init)
+
+    assert fetch_example("https://example.com", limit=7, retries=3) == "Example"
+    assert isinstance(created["max_retries"], Retry)
+    assert created["max_retries"].total == 3
+
+
+def test_fetch_example_env_timeout_and_retries(requests_mock, monkeypatch):
+    requests_mock.get("https://example.com", text="Example Domain", status_code=200)
+    monkeypatch.setenv("FETCH_TIMEOUT", "5")
+    monkeypatch.setenv("FETCH_RETRIES", "1")
+
+    captured: dict[str, int] = {}
+    original_get = requests.Session.get
+
+    def wrapped_get(self, url, **kwargs):  # type: ignore[override]
+        captured["timeout"] = kwargs.get("timeout")
+        return original_get(self, url, **kwargs)
+
+    monkeypatch.setattr(requests.Session, "get", wrapped_get)
+
+    assert fetch_example("https://example.com", limit=7) == "Example"
+    assert captured["timeout"] == 5


### PR DESCRIPTION
## Summary
- allow `fetch_example` to set request timeout and retries
- hook up `HTTPAdapter` with `Session` for retry logic
- document new `FETCH_TIMEOUT` and `FETCH_RETRIES` env vars and add tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a880f1e65c83269feb52fcddc01a85