### PR TITLE
Add aiohttp async fetching and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Ollama_CrewAi
 
-This project demonstrates how to fetch data from the web using Python's `requests` library. It provides a minimal example for educational purposes or as a base for experiments.
+This project demonstrates how to fetch data from the web using Python's `requests` library. It also includes an asynchronous example built with `aiohttp`. It provides a minimal example for educational purposes or as a base for experiments.
 
 ## Features
 
 - Simple `fetch_example` function that retrieves a snippet from a specified URL (defaults to [example.com](https://example.com)) with configurable character limit, timeout, and retry behavior.
-- Lightweight structure with a single dependency.
+- Optional asynchronous `fetch_example_async` using `aiohttp`.
+- Lightweight structure with minimal dependencies.
 
 ## Usage
 
@@ -17,6 +18,14 @@ python src/main.py
 
 You can customize the URL, length of the returned snippet, request timeout, and number of retries by passing arguments to `fetch_example` in `src/main.py`.
 
+To try the asynchronous version, run:
+
+```bash
+python src/main.py --async
+```
+
+The async entry point `main_async()` can also be invoked from other scripts.
+
 ## Installation
 
 Install the project and its dependencies with:
@@ -27,7 +36,7 @@ pip install .
 
 This will provide the CLI command `ollama-crewai`.
 
-Alternatively, install the required dependency listed in [requirements.txt](requirements.txt):
+Alternatively, install the required dependencies listed in [requirements.txt](requirements.txt):
 
 ```bash
 pip install -r requirements.txt
@@ -42,7 +51,7 @@ For a step-by-step setup guide, including how to use a virtual environment, see 
 Install the test dependencies and run the suite with:
 
 ```bash
-pip install -r requirements.txt pytest requests-mock
+pip install -r requirements.txt pytest requests-mock pytest-asyncio
 pytest
 ```
 
@@ -69,10 +78,15 @@ After installation the executable `ollama-crewai` is available. You can also run
 python src/main.py
 ```
 
+To use the asynchronous implementation from the command line:
+
+```bash
+python src/main.py --async
+```
+
 ## Possible extensions
 
 - Accept command-line arguments for URL and character limit.
-- Integrate asynchronous fetching or caching mechanisms.
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "ollama-crewai"
 version = "0.1.0"
 dependencies = [
     "requests>=2.31.0",
+    "aiohttp>=3.9.0",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests==2.31.0
+aiohttp==3.9.5

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,11 @@
+import argparse
+import asyncio
 import logging
 import os
 from typing import Optional
 
+import aiohttp
+import aiohttp.client_exceptions
 import requests
 import requests.exceptions
 from requests.adapters import HTTPAdapter
@@ -73,9 +77,77 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
+async def fetch_example_async(
+    url: Optional[str] = None,
+    limit: Optional[int] = None,
+    timeout: Optional[int] = None,
+    retries: Optional[int] = None,
+) -> str:
+    """Asynchronously fetch a snippet from the specified URL.
+
+    Args:
+        url (str, optional): Web address to retrieve. Defaults to the
+            ``FETCH_URL`` environment variable or ``"https://example.com"``.
+        limit (int, optional): Maximum number of characters to return from the
+            response body. Defaults to the ``FETCH_LIMIT`` environment variable
+            or ``100``.
+        timeout (int, optional): Number of seconds to wait for a response.
+            Defaults to the ``FETCH_TIMEOUT`` environment variable or ``10``.
+        retries (int, optional): Number of retry attempts for failed
+            requests. Defaults to the ``FETCH_RETRIES`` environment variable or
+            ``0``.
+
+    Returns:
+        str: A substring of the response body or an error message.
+
+    Raises:
+        ValueError: If ``limit`` is not a positive integer.
+    """
+    if url is None:
+        url = os.getenv("FETCH_URL", "https://example.com")
+    if limit is None:
+        limit_str = os.getenv("FETCH_LIMIT")
+        limit = int(limit_str) if limit_str is not None else 100
+    if timeout is None:
+        timeout_str = os.getenv("FETCH_TIMEOUT")
+        timeout = int(timeout_str) if timeout_str is not None else 10
+    if retries is None:
+        retries_str = os.getenv("FETCH_RETRIES")
+        retries = int(retries_str) if retries_str is not None else 0
+    if limit <= 0:
+        raise ValueError("limit must be positive")
+
+    for attempt in range(retries + 1):
+        try:
+            timeout_ctx = aiohttp.ClientTimeout(total=timeout)
+            async with aiohttp.ClientSession(timeout=timeout_ctx) as session:
+                async with session.get(url) as response:
+                    if response.status == 200:
+                        text = await response.text()
+                        return text[:limit]
+                    return "Error fetching data"
+        except aiohttp.client_exceptions.ClientError as exc:
+            if attempt == retries:
+                return f"Error fetching data: {exc}"
+    return "Error fetching data"
+
+
+async def main_async() -> None:
+    """Run example fetch asynchronously and log the result."""
+    logger.info(await fetch_example_async())
+
+
 def main() -> None:
     """Run example fetch and log the result."""
-    logger.info(fetch_example())
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--async", dest="use_async", action="store_true", help="Use asynchronous fetching"
+    )
+    args = parser.parse_args()
+    if args.use_async:
+        asyncio.run(main_async())
+    else:
+        logger.info(fetch_example())
 
 
 if __name__ == "__main__":

--- a/tests/test_main_async.py
+++ b/tests/test_main_async.py
@@ -1,0 +1,79 @@
+import pathlib
+import sys
+
+import aiohttp
+import pytest
+from aiohttp import web
+
+# Ensure the src directory is on the path for imports
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from main import fetch_example_async
+
+
+async def _start_test_server(handler, port):
+    app = web.Application()
+    app.router.add_get("/", handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "localhost", port)
+    await site.start()
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_fetch_example_async_success(unused_tcp_port):
+    async def handler(request):
+        return web.Response(text="Example Domain")
+
+    runner = await _start_test_server(handler, unused_tcp_port)
+    url = f"http://localhost:{unused_tcp_port}"
+    try:
+        assert await fetch_example_async(url, limit=7) == "Example"
+    finally:
+        await runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_fetch_example_async_http_error(unused_tcp_port):
+    async def handler(request):
+        return web.Response(status=404)
+
+    runner = await _start_test_server(handler, unused_tcp_port)
+    url = f"http://localhost:{unused_tcp_port}"
+    try:
+        assert await fetch_example_async(url) == "Error fetching data"
+    finally:
+        await runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_fetch_example_async_exception(monkeypatch):
+    def raise_error(self, url, **kwargs):  # type: ignore[override]
+        raise aiohttp.ClientError("boom")
+
+    monkeypatch.setattr(aiohttp.ClientSession, "get", raise_error)
+    result = await fetch_example_async("https://example.com")
+    assert result.startswith("Error fetching data:")
+
+
+@pytest.mark.asyncio
+async def test_fetch_example_async_invalid_limit():
+    with pytest.raises(ValueError):
+        await fetch_example_async(limit=0)
+
+
+@pytest.mark.asyncio
+async def test_fetch_example_async_env_vars(unused_tcp_port, monkeypatch):
+    async def handler(request):
+        return web.Response(text="Example Domain")
+
+    runner = await _start_test_server(handler, unused_tcp_port)
+    url = f"http://localhost:{unused_tcp_port}"
+    monkeypatch.setenv("FETCH_URL", url)
+    monkeypatch.setenv("FETCH_LIMIT", "7")
+    try:
+        assert await fetch_example_async() == "Example"
+    finally:
+        await runner.cleanup()
+


### PR DESCRIPTION
## Summary
- add `fetch_example_async` using aiohttp and expose `main_async`
- provide `--async` CLI flag to run async entry point
- document async usage and requirements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8821d8ea083269312fe32811119c6