### PR TITLE
Add pytest-asyncio plugin for async tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ For a step-by-step setup guide, including how to use a virtual environment, see 
 Install the test dependencies and run the suite with:
 
 ```bash
-pip install -r requirements.txt pytest requests-mock
+pip install -r requirements.txt pytest requests-mock pytest-asyncio
 pytest
 ```
+
+The test suite uses the `pytest-asyncio` plugin so asynchronous tests can be executed.
 
 ### Environment variables
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests==2.31.0
+pytest-asyncio


### PR DESCRIPTION
## Summary
- include `pytest-asyncio` in test dependencies
- document async pytest plugin in development instructions

## Testing
- `pip install pytest-asyncio`
- `pip install -r requirements.txt pytest requests-mock`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8d3b24f9483269b5d6cc64b5893f1