### PR TITLE
Add base Agent class and message interface

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,0 +1,6 @@
+"""Agents package providing base agent and messaging constructs."""
+
+from .base import Agent
+from .message import Message
+
+__all__ = ["Agent", "Message"]

--- a/src/agents/base.py
+++ b/src/agents/base.py
@@ -1,0 +1,34 @@
+"""Base agent definitions."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from .message import Message
+
+
+class Agent(ABC):
+    """Abstract base class for agents participating in a conversation.
+
+    Subclasses must provide concrete implementations for the planning,
+    acting and observing steps of an agent. All communication between
+    agents is performed via :class:`~agents.message.Message` instances.
+    """
+
+    @abstractmethod
+    def plan(self) -> Message:
+        """Generate a plan represented as a :class:`Message`."""
+
+    @abstractmethod
+    def act(self, message: Message) -> Message:
+        """Perform an action based on ``message`` and return the response.
+
+        Parameters
+        ----------
+        message:
+            The incoming :class:`Message` that should trigger the action.
+        """
+
+    @abstractmethod
+    def observe(self, message: Message) -> None:
+        """Observe an incoming :class:`Message` and update internal state."""

--- a/src/agents/message.py
+++ b/src/agents/message.py
@@ -1,0 +1,26 @@
+"""Messaging constructs for agent communication."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+@dataclass(slots=True)
+class Message:
+    """Represents a message exchanged between agents.
+
+    Parameters
+    ----------
+    sender:
+        Identifier of the agent sending the message.
+    content:
+        The textual content of the message.
+    metadata:
+        Optional dictionary carrying arbitrary metadata associated with the
+        message (timestamps, routing information, etc.).
+    """
+
+    sender: str
+    content: str
+    metadata: Optional[Dict[str, Any]] = field(default=None)

--- a/tests/test_agents_base.py
+++ b/tests/test_agents_base.py
@@ -1,0 +1,46 @@
+import pathlib
+import sys
+
+import pytest
+
+# Ensure src directory on path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from agents import Agent, Message
+
+
+class DummyAgent(Agent):
+    """Simple concrete implementation of :class:`Agent` used for testing."""
+
+    def __init__(self) -> None:
+        self.observed: list[Message] = []
+
+    def plan(self) -> Message:  # type: ignore[override]
+        return Message(sender="dummy", content="plan")
+
+    def act(self, message: Message) -> Message:  # type: ignore[override]
+        return Message(sender="dummy", content=message.content.upper())
+
+    def observe(self, message: Message) -> None:  # type: ignore[override]
+        self.observed.append(message)
+
+
+def test_agent_is_abstract() -> None:
+    with pytest.raises(TypeError):
+        Agent()  # type: ignore[abstract]
+
+
+def test_concrete_agent_behaviour() -> None:
+    agent = DummyAgent()
+    plan_msg = agent.plan()
+    assert isinstance(plan_msg, Message)
+    response = agent.act(Message(sender="tester", content="hello"))
+    assert response.content == "HELLO"
+    agent.observe(response)
+    assert agent.observed[-1] == response
+
+
+def test_message_dataclass() -> None:
+    message = Message(sender="alice", content="hello", metadata={"time": 1})
+    assert message.sender == "alice"
+    assert message.metadata == {"time": 1}


### PR DESCRIPTION
## Summary
- add abstract Agent base class with plan, act, and observe hooks
- introduce Message dataclass for structured agent communication
- cover agent and message behavior with new unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8e3fcb6b0832680e6a6f900b1d713