### PR TITLE
feat: introduce manager agent with asyncio orchestration

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -2,5 +2,6 @@
 
 from .base import Agent
 from .message import Message
+from .manager import Manager
 
-__all__ = ["Agent", "Message"]
+__all__ = ["Agent", "Message", "Manager"]

--- a/src/agents/manager.py
+++ b/src/agents/manager.py
@@ -1,0 +1,73 @@
+"""Manager agent orchestrating multiple specialized agents."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+from .base import Agent
+from .message import Message
+
+
+@dataclass
+class Manager(Agent):
+    """Agent responsible for coordinating other agents.
+
+    Parameters
+    ----------
+    agents:
+        Mapping of agent names to agent instances that will receive tasks.
+    """
+
+    agents: Dict[str, Agent]
+
+    def __post_init__(self) -> None:
+        self._queue: asyncio.Queue[Tuple[str, Message]] = asyncio.Queue()
+        self._results: List[Message] = []
+        self._objective: str | None = None
+
+    # -- Agent API -----------------------------------------------------
+    def plan(self) -> Message:  # type: ignore[override]
+        """Split the global objective into discrete tasks."""
+        if not self._objective:
+            raise ValueError("No objective set")
+
+        tasks = [t.strip() for t in self._objective.split(".") if t.strip()]
+        return Message(sender="manager", content="plan", metadata={"tasks": tasks})
+
+    def act(self, message: Message) -> Message:  # type: ignore[override]
+        """Distribute tasks round-robin to specialized agents."""
+        tasks: List[str] = message.metadata.get("tasks", []) if message.metadata else []
+        agent_names = list(self.agents.keys())
+        for idx, task in enumerate(tasks):
+            target = agent_names[idx % len(agent_names)]
+            self._queue.put_nowait((target, Message(sender="manager", content=task)))
+        return Message(sender="manager", content="dispatched", metadata={"tasks": tasks})
+
+    def observe(self, message: Message) -> None:  # type: ignore[override]
+        """Collect results produced by specialized agents."""
+        self._results.append(message)
+
+    # -- Orchestration -------------------------------------------------
+    async def run(self, objective: str) -> List[Message]:
+        """Run the orchestration process for ``objective``.
+
+        The objective is split into tasks, dispatched to agents and results
+        collected. Returns the list of responses from agents.
+        """
+
+        self._objective = objective
+        plan_msg = self.plan()
+        self.act(plan_msg)
+        await self._process_queue()
+        return self._results
+
+    async def _process_queue(self) -> None:
+        while not self._queue.empty():
+            target, message = await self._queue.get()
+            agent = self.agents[target]
+            response = agent.act(message)
+            agent.observe(response)
+            self.observe(response)
+            self._queue.task_done()

--- a/tests/test_manager_agent.py
+++ b/tests/test_manager_agent.py
@@ -1,0 +1,41 @@
+import pathlib
+import sys
+
+import pytest
+
+# Ensure src directory on path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from agents import Agent, Message
+from agents.manager import Manager
+
+
+class WorkerAgent(Agent):
+    """Simple agent that capitalizes tasks it receives."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.observed: list[Message] = []
+
+    def plan(self) -> Message:  # type: ignore[override]
+        return Message(sender=self.name, content="ready")
+
+    def act(self, message: Message) -> Message:  # type: ignore[override]
+        self.observed.append(message)
+        return Message(sender=self.name, content=message.content.upper())
+
+    def observe(self, message: Message) -> None:  # type: ignore[override]
+        self.observed.append(message)
+
+
+@pytest.mark.asyncio
+async def test_manager_orchestration() -> None:
+    worker1 = WorkerAgent("w1")
+    worker2 = WorkerAgent("w2")
+    manager = Manager({"w1": worker1, "w2": worker2})
+
+    results = await manager.run("alpha. beta.")
+
+    assert [msg.content for msg in results] == ["ALPHA", "BETA"]
+    assert worker1.observed[0].content == "alpha"
+    assert worker2.observed[0].content == "beta"


### PR DESCRIPTION
## Summary
- expose Manager agent from package
- implement Manager to split objectives into tasks and dispatch to worker agents using an asyncio.Queue
- add test covering manager orchestration across workers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8e4e473648326a0265413791f6eaa