### PR TITLE
Add specialized agent modules with tests

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -3,5 +3,19 @@
 from .base import Agent
 from .message import Message
 from .manager import Manager
+from .planner import PlannerAgent
+from .researcher import ResearcherAgent
+from .developer import DeveloperAgent
+from .tester import TesterAgent
+from .writer import WriterAgent
 
-__all__ = ["Agent", "Message", "Manager"]
+__all__ = [
+    "Agent",
+    "Message",
+    "Manager",
+    "PlannerAgent",
+    "ResearcherAgent",
+    "DeveloperAgent",
+    "TesterAgent",
+    "WriterAgent",
+]

--- a/src/agents/developer.py
+++ b/src/agents/developer.py
@@ -1,0 +1,36 @@
+"""Developer agent responsible for code generation and file interactions."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .base import Agent
+from .message import Message
+
+
+@dataclass
+class DeveloperAgent(Agent):
+    """Agent that writes provided code snippets to the filesystem."""
+
+    capabilities: list[str] = field(default_factory=lambda: ["coding", "file-writing"])
+    tools: list[str] = field(default_factory=lambda: ["filesystem"])
+    last_written: Path | None = None
+
+    def plan(self) -> Message:  # type: ignore[override]
+        return Message(sender="developer", content="ready")
+
+    def act(self, message: Message) -> Message:  # type: ignore[override]
+        metadata = message.metadata or {}
+        path_value = metadata.get("path")
+        code = metadata.get("code", "")
+        if path_value:
+            path = Path(path_value)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(code)
+            self.last_written = path
+            return Message(sender="developer", content=f"wrote {path}")
+        return Message(sender="developer", content="no action")
+
+    def observe(self, message: Message) -> None:  # type: ignore[override]
+        if message.content.startswith("wrote"):
+            self.last_written = Path(message.content.split(" ", 1)[1])

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -1,0 +1,31 @@
+"""Planner agent for project decomposition."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+from .base import Agent
+from .message import Message
+
+
+@dataclass
+class PlannerAgent(Agent):
+    """Agent that decomposes objectives into smaller tasks."""
+
+    capabilities: list[str] = field(default_factory=lambda: ["planning", "decomposition"])
+    tools: list[str] = field(default_factory=list)
+    tasks: List[str] = field(default_factory=list)
+
+    def plan(self) -> Message:  # type: ignore[override]
+        """Return a simple readiness message."""
+        return Message(sender="planner", content="ready")
+
+    def act(self, message: Message) -> Message:  # type: ignore[override]
+        """Split the incoming objective into discrete tasks."""
+        self.tasks = [t.strip() for t in message.content.split(".") if t.strip()]
+        return Message(sender="planner", content="plan", metadata={"tasks": self.tasks})
+
+    def observe(self, message: Message) -> None:  # type: ignore[override]
+        """Store observed tasks for later reference."""
+        if message.metadata:
+            self.tasks = message.metadata.get("tasks", [])

--- a/src/agents/researcher.py
+++ b/src/agents/researcher.py
@@ -1,0 +1,36 @@
+"""Researcher agent for web information gathering."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import requests
+
+from .base import Agent
+from .message import Message
+
+
+@dataclass
+class ResearcherAgent(Agent):
+    """Agent that fetches information from the web using ``requests``."""
+
+    capabilities: list[str] = field(default_factory=lambda: ["research", "web-fetch"])
+    tools: list[str] = field(default_factory=lambda: ["requests"])
+    last_response: str | None = None
+
+    def plan(self) -> Message:  # type: ignore[override]
+        return Message(sender="researcher", content="ready")
+
+    def act(self, message: Message) -> Message:  # type: ignore[override]
+        url = message.content
+        try:
+            response = requests.get(url, timeout=5)
+            response.raise_for_status()
+            text = response.text[:200]
+            self.last_response = text
+            return Message(sender="researcher", content=text)
+        except Exception as exc:  # pragma: no cover - network error paths
+            error = f"error: {exc}"
+            self.last_response = error
+            return Message(sender="researcher", content=error)
+
+    def observe(self, message: Message) -> None:  # type: ignore[override]
+        self.last_response = message.content

--- a/src/agents/tester.py
+++ b/src/agents/tester.py
@@ -1,0 +1,37 @@
+"""Tester agent for executing test suites."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import subprocess
+from typing import List
+
+from .base import Agent
+from .message import Message
+
+
+@dataclass
+class TesterAgent(Agent):
+    """Agent that runs pytest and returns the results."""
+
+    capabilities: list[str] = field(default_factory=lambda: ["testing"])
+    tools: list[str] = field(default_factory=lambda: ["pytest"])
+    last_result: str | None = None
+
+    def plan(self) -> Message:  # type: ignore[override]
+        return Message(sender="tester", content="ready")
+
+    def act(self, message: Message) -> Message:  # type: ignore[override]
+        command = message.content or "pytest"
+        try:
+            result = subprocess.run(
+                command.split(), capture_output=True, text=True, check=True
+            )
+            self.last_result = result.stdout
+            return Message(sender="tester", content="success", metadata={"output": result.stdout})
+        except subprocess.CalledProcessError as exc:  # pragma: no cover - failure path
+            self.last_result = exc.stderr
+            return Message(sender="tester", content="failure", metadata={"error": exc.stderr})
+
+    def observe(self, message: Message) -> None:  # type: ignore[override]
+        if message.metadata:
+            self.last_result = message.metadata.get("output") or message.metadata.get("error")

--- a/src/agents/tester.py
+++ b/src/agents/tester.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import subprocess
-from typing import List
 
 from .base import Agent
 from .message import Message

--- a/src/agents/writer.py
+++ b/src/agents/writer.py
@@ -1,0 +1,37 @@
+"""Writer agent for generating documentation."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List
+
+from .base import Agent
+from .message import Message
+
+
+@dataclass
+class WriterAgent(Agent):
+    """Agent that writes documentation files to the filesystem."""
+
+    capabilities: list[str] = field(default_factory=lambda: ["documentation"])
+    tools: list[str] = field(default_factory=lambda: ["filesystem"])
+    documents: List[Path] = field(default_factory=list)
+
+    def plan(self) -> Message:  # type: ignore[override]
+        return Message(sender="writer", content="ready")
+
+    def act(self, message: Message) -> Message:  # type: ignore[override]
+        metadata = message.metadata or {}
+        path_value = metadata.get("path")
+        text = metadata.get("text", "")
+        if path_value:
+            path = Path(path_value)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(text)
+            self.documents.append(path)
+            return Message(sender="writer", content=f"wrote {path}")
+        return Message(sender="writer", content="no document")
+
+    def observe(self, message: Message) -> None:  # type: ignore[override]
+        if message.content.startswith("wrote"):
+            self.documents.append(Path(message.content.split(" ", 1)[1]))

--- a/tests/test_developer_agent.py
+++ b/tests/test_developer_agent.py
@@ -1,0 +1,27 @@
+import pathlib
+import sys
+
+# Ensure src directory on path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from agents import Message
+from agents.developer import DeveloperAgent
+
+
+def test_developer_writes_code(tmp_path):
+    developer = DeveloperAgent()
+    target = tmp_path / "example.py"
+    msg = Message(
+        sender="tester",
+        content="write",
+        metadata={"path": target, "code": "print('hi')"},
+    )
+
+    response = developer.act(msg)
+
+    assert target.read_text() == "print('hi')"
+    assert response.content == f"wrote {target}"
+
+    developer.observe(response)
+    assert developer.last_written == target
+    assert "coding" in developer.capabilities

--- a/tests/test_planner_agent.py
+++ b/tests/test_planner_agent.py
@@ -1,0 +1,19 @@
+import pathlib
+import sys
+
+# Ensure src directory on path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from agents import Message
+from agents.planner import PlannerAgent
+
+
+def test_planner_decomposes_tasks():
+    planner = PlannerAgent()
+    msg = Message(sender="tester", content="alpha. beta.")
+    response = planner.act(msg)
+
+    assert response.metadata["tasks"] == ["alpha", "beta"]
+    planner.observe(response)
+    assert planner.tasks == ["alpha", "beta"]
+    assert "planning" in planner.capabilities


### PR DESCRIPTION
## Summary
- add planner, researcher, developer, tester and writer agent modules inheriting from `Agent`
- expose new agents in package exports
- test developer file-writing and planner task decomposition

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8e6261c788326b01c1de878c64328