### PR TITLE
Add agent orchestration CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,22 @@ After installation the executable `ollama-crewai` is available. You can also run
 python src/main.py
 ```
 
+### Agent orchestration CLI
+
+The package also exposes a small orchestrator for the demo agents. Run
+it with:
+
+```bash
+ollama-crewai-agents [-c config/agents.yaml] [--debug]
+```
+
+* `-c`, `--config` – path to the YAML or JSON configuration file
+  describing the agents and default objective (defaults to
+  `config/agents.yaml`).
+* `--debug` – enable verbose logging to aid debugging.
+
+The repository ships with a sample configuration file in `config/agents.yaml`.
+
 ## Possible extensions
 
 - Accept command-line arguments for URL and character limit.

--- a/config/agents.yaml
+++ b/config/agents.yaml
@@ -1,0 +1,6 @@
+objective: "Plan. Implement. Test."
+agents:
+  planner: {}
+  developer: {}
+  writer: {}
+  tester: {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,14 @@ name = "ollama-crewai"
 version = "0.1.0"
 dependencies = [
     "requests>=2.31.0",
+    "pyyaml>=6.0",
 ]
 
 [project.scripts]
 ollama-crewai = "main:main"
+ollama-crewai-agents = "cli:main"
 
 [tool.setuptools]
-py-modules = ["main"]
+packages = ["agents", "core"]
+py-modules = ["main", "cli"]
 package-dir = {"" = "src"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 requests==2.31.0
 pytest-asyncio
+PyYAML>=6.0
+requests-mock

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,103 @@
+"""Command-line interface for configuring and running agents.
+
+This module reads a YAML or JSON configuration file describing the
+available agents and creates a :class:`~agents.manager.Manager`
+accordingly.  It also exposes a small CLI utility used via the
+``ollama-crewai-agents`` entry point.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+from agents.developer import DeveloperAgent
+from agents.manager import Manager
+from agents.planner import PlannerAgent
+from agents.researcher import ResearcherAgent
+from agents.tester import TesterAgent
+from agents.writer import WriterAgent
+
+# Mapping from config keys to concrete agent classes
+AGENT_TYPES = {
+    "planner": PlannerAgent,
+    "developer": DeveloperAgent,
+    "writer": WriterAgent,
+    "tester": TesterAgent,
+    "researcher": ResearcherAgent,
+}
+
+
+def load_config(path: Path) -> Dict[str, Any]:
+    """Load a YAML or JSON configuration file.
+
+    Parameters
+    ----------
+    path:
+        Path to the configuration file.
+    """
+
+    text = path.read_text(encoding="utf-8")
+    if path.suffix in {".yaml", ".yml"}:
+        return yaml.safe_load(text)
+    if path.suffix == ".json":
+        return json.loads(text)
+    raise ValueError(f"Unsupported config format: {path.suffix}")
+
+
+def build_manager(config: Dict[str, Any]) -> Manager:
+    """Create a :class:`Manager` based on ``config``.
+
+    The configuration should contain an ``agents`` mapping where each key
+    corresponds to an agent type listed in :data:`AGENT_TYPES`.
+    """
+
+    agents_cfg = config.get("agents", {})
+    instances: Dict[str, Any] = {}
+    for name, params in agents_cfg.items():
+        cls = AGENT_TYPES.get(name)
+        if cls is None:
+            raise ValueError(f"Unknown agent type: {name}")
+        if isinstance(params, dict):
+            instances[name] = cls(**params)
+        else:
+            instances[name] = cls()
+    return Manager(instances)
+
+
+def main() -> None:
+    """Entry point for the ``ollama-crewai-agents`` script."""
+
+    parser = argparse.ArgumentParser(description="Run Ollama CrewAI agents")
+    parser.add_argument(
+        "-c",
+        "--config",
+        default="config/agents.yaml",
+        help="Path to YAML or JSON configuration file",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug logging",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
+
+    cfg = load_config(Path(args.config))
+    manager = build_manager(cfg)
+    objective = cfg.get("objective", "")
+
+    tasks = asyncio.run(manager.run(objective))
+    for task in tasks:
+        logging.info("%s: %s", task.id, task.result or task.status.name)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution only
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,22 @@
+import asyncio
+import pathlib
+import sys
+
+# Ensure src directory is on the path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+import cli  # type: ignore
+
+
+def test_cli_load_and_run(tmp_path):
+    cfg_file = tmp_path / "agents.yaml"
+    cfg_file.write_text(
+        "objective: 'alpha. beta.'\n"
+        "agents:\n"
+        "  planner: {}\n"
+        "  developer: {}\n"
+    )
+    cfg = cli.load_config(cfg_file)
+    manager = cli.build_manager(cfg)
+    tasks = asyncio.run(manager.run(cfg["objective"]))
+    assert len(tasks) == 2


### PR DESCRIPTION
## Summary
- add `cli.py` providing `ollama-crewai-agents` entry point with config and debug options
- load agents from YAML/JSON config and run manager
- document new CLI and ship sample `config/agents.yaml`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a941d913808326bbef1d99a7dafc4b