### PR TITLE
docs: add agent configuration guide and CLI env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,16 @@ The script honors several optional environment variables:
 - `FETCH_LIMIT`: Number of characters to display (defaults to `100`).
 - `FETCH_TIMEOUT`: Timeout in seconds for the request (defaults to `10`).
 - `FETCH_RETRIES`: Number of retry attempts for failed requests (defaults to `0`).
+- `AGENTS_CONFIG`: Path to the agent configuration file used by
+  `ollama-crewai-agents` (defaults to `config/agents.yaml`).
+- `AGENTS_DEBUG`: When set to `1`, `true`, or `yes`, enables debug logging
+  for agent orchestration.
 
 You can set them inline when invoking the CLI:
 
 ```bash
 FETCH_URL=https://example.org FETCH_LIMIT=50 ollama-crewai
+AGENTS_CONFIG=config/agents.yaml AGENTS_DEBUG=1 ollama-crewai-agents
 ```
 
 ### Command-line usage
@@ -98,6 +103,35 @@ ollama-crewai-agents [-c config/agents.yaml] [--debug]
 * `--debug` – enable verbose logging to aid debugging.
 
 The repository ships with a sample configuration file in `config/agents.yaml`.
+
+### Agent configuration and workflow
+
+Agents are declared in a YAML or JSON file.  The manager loads this
+configuration, splits the global ``objective`` into tasks, and
+distributes them round-robin to the registered agents, collecting their
+results as they complete the work.
+
+Example configuration:
+
+```yaml
+objective: "plan feature. implement feature. test feature."
+agents:
+  planner: {}
+  developer: {}
+  tester: {}
+```
+
+Run the manager with the configuration file and optional debugging:
+
+```bash
+ollama-crewai-agents -c config/agents.yaml --debug
+# or rely on environment variables
+AGENTS_CONFIG=config/agents.yaml AGENTS_DEBUG=1 ollama-crewai-agents
+```
+
+During execution the manager coordinates the agents and reports the
+status of each task in the log output, providing a clear view of the
+overall workflow.
 
 ## Possible extensions
 

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="160">
+  <rect x="110" y="20" width="80" height="40" fill="#f0f0f0" stroke="#000"/>
+  <text x="150" y="45" font-size="12" text-anchor="middle">Manager</text>
+
+  <rect x="20" y="100" width="80" height="40" fill="#f0f0f0" stroke="#000"/>
+  <text x="60" y="125" font-size="12" text-anchor="middle">Planner</text>
+
+  <rect x="110" y="100" width="80" height="40" fill="#f0f0f0" stroke="#000"/>
+  <text x="150" y="125" font-size="12" text-anchor="middle">Developer</text>
+
+  <rect x="200" y="100" width="80" height="40" fill="#f0f0f0" stroke="#000"/>
+  <text x="240" y="125" font-size="12" text-anchor="middle">Tester</text>
+
+  <line x1="150" y1="60" x2="60" y2="100" stroke="#000"/>
+  <line x1="150" y1="60" x2="150" y2="100" stroke="#000"/>
+  <line x1="150" y1="60" x2="240" y2="100" stroke="#000"/>
+</svg>

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,0 +1,40 @@
+# Tutorial
+
+This tutorial walks through configuring agents and running a workflow with the manager.
+
+## Architecture
+
+![Manager and agents](architecture.svg)
+
+## Configuration
+
+Agents are declared in a YAML or JSON file. Example `config/agents.yaml`:
+
+```yaml
+objective: "plan feature. implement feature. test feature."
+agents:
+  planner: {}
+  developer: {}
+  tester: {}
+```
+
+## Running the workflow
+
+Execute the manager via the CLI:
+
+```bash
+ollama-crewai-agents -c config/agents.yaml --debug
+```
+
+Environment variables may also be used to provide defaults:
+
+```bash
+AGENTS_CONFIG=config/agents.yaml AGENTS_DEBUG=1 ollama-crewai-agents
+```
+
+## Workflow overview
+
+1. The manager reads the `objective` from the configuration.
+2. It splits the objective into discrete tasks.
+3. Tasks are dispatched round-robin to the agents.
+4. Agents process tasks and report results back to the manager.

--- a/src/cli.py
+++ b/src/cli.py
@@ -15,6 +15,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, cast
 
+import os
 import yaml
 
 from agents.developer import DeveloperAgent
@@ -74,16 +75,20 @@ def build_manager(config: Dict[str, Any]) -> Manager:
 def main() -> None:
     """Entry point for the ``ollama-crewai-agents`` script."""
 
+    default_config = os.getenv("AGENTS_CONFIG", "config/agents.yaml")
+    debug_default = os.getenv("AGENTS_DEBUG", "").lower() in {"1", "true", "yes"}
+
     parser = argparse.ArgumentParser(description="Run Ollama CrewAI agents")
     parser.add_argument(
         "-c",
         "--config",
-        default="config/agents.yaml",
+        default=default_config,
         help="Path to YAML or JSON configuration file",
     )
     parser.add_argument(
         "--debug",
         action="store_true",
+        default=debug_default,
         help="Enable debug logging",
     )
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- document agent setup, manager workflow, and new env vars
- add detailed tutorial and architecture diagram for agent orchestration
- support AGENTS_CONFIG and AGENTS_DEBUG defaults in CLI

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a949d484308326a225d7be5e5a05df