### PR TITLE
feat: allow dynamic agent registration

### DIFF
--- a/docs/extension.md
+++ b/docs/extension.md
@@ -1,0 +1,42 @@
+# Création d'un agent personnalisé
+
+Ce guide décrit comment ajouter un nouvel agent à **Ollama CrewAi**.
+
+## 1. Hériter de `Agent`
+
+Créez une sous-classe de `agents.base.Agent` et implémentez les méthodes
+obligatoires :
+
+```python
+from agents.base import Agent
+from agents.message import Message
+
+class MonAgent(Agent):
+    def plan(self) -> Message:
+        return Message(sender="mon_agent", content="prêt")
+
+    def act(self, message: Message) -> Message:
+        # traitement du message
+        return Message(sender="mon_agent", content=message.content.upper(), metadata=message.metadata)
+
+    def observe(self, message: Message) -> None:
+        pass
+```
+
+## 2. Enregistrer l'agent auprès du manager
+
+Instanciez un `Manager` puis enregistrez dynamiquement votre agent via
+`register_agent` :
+
+```python
+from agents.manager import Manager
+
+manager = Manager()
+manager.register_agent("mon_agent", MonAgent())
+```
+
+Le manager se charge de connecter l'agent au bus de messages et de créer
+sa file de messages.
+
+Un exemple complet est disponible dans
+[`examples/custom_agent.py`](../examples/custom_agent.py).

--- a/examples/custom_agent.py
+++ b/examples/custom_agent.py
@@ -1,0 +1,34 @@
+"""Example of creating and registering a custom agent."""
+
+from __future__ import annotations
+
+import asyncio
+
+from agents.base import Agent
+from agents.manager import Manager
+from agents.message import Message
+
+
+class EchoAgent(Agent):
+    """Agent that uppercases any received task."""
+
+    def plan(self) -> Message:  # type: ignore[override]
+        return Message(sender="echo", content="ready")
+
+    def act(self, message: Message) -> Message:  # type: ignore[override]
+        return Message(sender="echo", content=message.content.upper(), metadata=message.metadata)
+
+    def observe(self, message: Message) -> None:  # type: ignore[override]
+        print(f"EchoAgent observed: {message.content}")
+
+
+async def main() -> None:
+    manager = Manager()
+    manager.register_agent("echo", EchoAgent())
+    tasks = await manager.run("salut.")
+    for task in tasks:
+        print(f"Task {task.id}: {task.result}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- document how to extend the framework with custom agents
- add `register_agent()` for dynamic agent registration in the manager
- include example echo agent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a94d9dba8083269ac76f1dc82712b4