### PR TITLE
feat: async researcher and tester agents

### DIFF
--- a/src/agents/base.py
+++ b/src/agents/base.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 import asyncio
+import inspect
+from typing import Awaitable
 
 from core.bus import MessageBus
 from .message import Message
@@ -26,7 +28,7 @@ class Agent(ABC):
         """Generate a plan represented as a :class:`Message`."""
 
     @abstractmethod
-    def act(self, message: Message) -> Message:
+    def act(self, message: Message) -> Message | Awaitable[Message]:
         """Perform an action based on ``message`` and return the response.
 
         Parameters
@@ -53,6 +55,8 @@ class Agent(ABC):
         while True:
             message = await self.queue.get()
             response = self.act(message)
+            if inspect.isawaitable(response):
+                response = await response
             self.observe(response)
 
             metadata: dict[str, object] = {}

--- a/src/agents/tester.py
+++ b/src/agents/tester.py
@@ -28,11 +28,15 @@ class TesterAgent(Agent):
     def plan(self) -> Message:
         return Message(sender="tester", content="ready")
 
-    def act(self, message: Message) -> Message:
+    async def act(self, message: Message) -> Message:
         command = message.content or "pytest"
         try:
-            result = subprocess.run(
-                command.split(), capture_output=True, text=True, check=True
+            result = await asyncio.to_thread(
+                subprocess.run,
+                command.split(),
+                capture_output=True,
+                text=True,
+                check=True,
             )
             self.last_result = result.stdout
             return Message(sender="tester", content="success", metadata={"output": result.stdout})

--- a/tests/test_researcher_agent.py
+++ b/tests/test_researcher_agent.py
@@ -1,0 +1,46 @@
+import pathlib
+import sys
+import inspect
+import pytest
+
+# Ensure src directory on path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from agents import Message
+from agents.researcher import ResearcherAgent
+
+
+@pytest.mark.asyncio
+async def test_researcher_act_async(monkeypatch):
+    """ResearcherAgent.act should be asynchronous and fetch data."""
+
+    class DummyResponse:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def text(self):
+            return "dummy response"
+
+        def raise_for_status(self):
+            return None
+
+    class DummySession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, url):
+            return DummyResponse()
+
+    monkeypatch.setattr("agents.researcher.aiohttp.ClientSession", lambda *args, **kwargs: DummySession())
+
+    agent = ResearcherAgent()
+    assert inspect.iscoroutinefunction(agent.act)
+    response = await agent.act(Message(sender="tester", content="http://example.com"))
+    assert response.content == "dummy response"
+    assert agent.last_response == "dummy response"

--- a/tests/test_tester_agent.py
+++ b/tests/test_tester_agent.py
@@ -1,0 +1,30 @@
+import pathlib
+import sys
+import inspect
+import pytest
+
+# Ensure src directory on path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from agents import Message
+from agents.tester import TesterAgent
+
+
+@pytest.mark.asyncio
+async def test_tester_act_async(monkeypatch):
+    """TesterAgent.act should run subprocess in a thread and be async."""
+
+    def fake_run(cmd, capture_output, text, check):
+        class Result:
+            stdout = "ok"
+            stderr = ""
+        return Result()
+
+    monkeypatch.setattr("agents.tester.subprocess.run", fake_run)
+
+    agent = TesterAgent()
+    assert inspect.iscoroutinefunction(agent.act)
+    response = await agent.act(Message(sender="manager", content="echo hi"))
+    assert response.content == "success"
+    assert response.metadata["output"] == "ok"
+    assert agent.last_result == "ok"


### PR DESCRIPTION
## Summary
- switch ResearcherAgent to async `aiohttp` implementation
- run TesterAgent subprocesses asynchronously in a thread
- support async `act` methods in base Agent and cover with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a952bcaa1083269bd6c923b67decc8