### PR TITLE
Add tests for researcher and writer agents

### DIFF
--- a/tests/test_writer_agent.py
+++ b/tests/test_writer_agent.py
@@ -1,0 +1,31 @@
+import pathlib
+import sys
+import pytest
+
+# Ensure src directory on path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from agents import Message
+from agents.writer import WriterAgent
+
+
+def test_writer_act_writes_file_and_updates_documents(tmp_path):
+    agent = WriterAgent()
+    file_path = tmp_path / "docs" / "output.txt"
+    message = Message(sender="tester", content="", metadata={"path": str(file_path), "text": "hello"})
+
+    response = agent.act(message)
+
+    assert file_path.read_text() == "hello"
+    assert agent.documents == [file_path]
+    assert response.content == f"wrote {file_path}"
+
+
+def test_writer_observe_adds_document(tmp_path):
+    agent = WriterAgent()
+    file_path = tmp_path / "docs" / "extra.txt"
+    message = Message(sender="manager", content=f"wrote {file_path}")
+
+    agent.observe(message)
+
+    assert agent.documents == [file_path]


### PR DESCRIPTION
## Summary
- add requests_mock-based test for ResearcherAgent
- add WriterAgent tests verifying file creation and document tracking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a95488fd20832686c212ccdf657519