### PR TITLE
Configure agent models and add supervised CLI

### DIFF
--- a/config/agents.yaml
+++ b/config/agents.yaml
@@ -1,6 +1,17 @@
 objective: "Plan. Implement. Test."
 agents:
-  planner: {}
-  developer: {}
-  writer: {}
-  tester: {}
+  planner:
+    model: gpt-4
+    tools: []
+  developer:
+    model: gpt-4
+    tools: [filesystem]
+  writer:
+    model: gpt-4
+    tools: [filesystem]
+  tester:
+    model: gpt-4
+    tools: [pytest]
+  researcher:
+    model: gpt-4
+    tools: [aiohttp]

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -16,7 +16,7 @@ from .message import Message
 @dataclass
 class PlannerAgent(Agent):
     """Agent that decomposes objectives into smaller tasks."""
-
+    model: str = "gpt-4"
     capabilities: list[str] = field(default_factory=lambda: ["planning", "decomposition"])
     tools: list[str] = field(default_factory=list)
     tasks: List[str] = field(default_factory=list)

--- a/src/agents/researcher.py
+++ b/src/agents/researcher.py
@@ -16,7 +16,7 @@ from .message import Message
 @dataclass
 class ResearcherAgent(Agent):
     """Agent that fetches information from the web using ``aiohttp``."""
-
+    model: str = "gpt-4"
     capabilities: list[str] = field(default_factory=lambda: ["research", "web-fetch"])
     tools: list[str] = field(default_factory=lambda: ["aiohttp"])
     last_response: str | None = None

--- a/src/agents/tester.py
+++ b/src/agents/tester.py
@@ -16,7 +16,7 @@ from .message import Message
 @dataclass
 class TesterAgent(Agent):
     """Agent that runs pytest and returns the results."""
-
+    model: str = "gpt-4"
     capabilities: list[str] = field(default_factory=lambda: ["testing"])
     tools: list[str] = field(default_factory=lambda: ["pytest"])
     last_result: str | None = None

--- a/src/agents/writer.py
+++ b/src/agents/writer.py
@@ -17,7 +17,7 @@ from .message import Message
 @dataclass
 class WriterAgent(Agent):
     """Agent that writes documentation files to the filesystem."""
-
+    model: str = "gpt-4"
     capabilities: list[str] = field(default_factory=lambda: ["documentation"])
     tools: list[str] = field(default_factory=lambda: ["filesystem"])
     documents: List[Path] = field(default_factory=list)

--- a/tests/test_full_team.py
+++ b/tests/test_full_team.py
@@ -1,0 +1,47 @@
+import asyncio
+import pathlib
+import sys
+
+import pytest
+
+# Ensure src directory on path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+import cli  # type: ignore
+from agents.message import Message
+from core.task import TaskStatus
+from core import policies
+
+
+def test_full_team_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        policies,
+        "ALLOWED_COMMANDS",
+        {"plan", "code", "write", "echo", "research"},
+    )
+    monkeypatch.setattr(policies, "NETWORK_ACCESS", True)
+
+    cfg = {
+        "objective": "plan tasks. code feature. write docs. echo hi. research example.",
+        "agents": {
+            "planner": {},
+            "developer": {},
+            "writer": {},
+            "tester": {},
+            "researcher": {},
+        },
+    }
+    manager = cli.build_manager(cfg)
+
+    async def orchestrate():
+        run_task = asyncio.create_task(manager.run(cfg["objective"]))
+        plan = await asyncio.wait_for(manager.bus.recv_from_supervisor(), timeout=1)
+        assert plan.content == "plan"
+        manager.bus.send_to_supervisor(Message(sender="supervisor", content="approve"))
+        return await run_task
+
+    tasks = asyncio.run(orchestrate())
+    assert len(tasks) == 5
+    assert all(t.status is TaskStatus.DONE for t in tasks)
+    assert tasks[3].result == "success"
+    assert tasks[4].result.startswith("error")


### PR DESCRIPTION
## Summary
- define model and tools for each agent in `agents.yaml`
- allow developer agent to read files and expose model field on agents
- add supervised run utility in CLI
- include integration test exercising all agents

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa44b77eb0832681fcdfa7122927ec