### PR TITLE
feat: persist supervisor communication

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -50,3 +50,19 @@ INFO|developer|1|completed
 
 The logger is automatically injected into all agents and the manager, so
 logs are emitted during task processing without extra setup.
+
+## Resuming a workflow
+
+The manager can persist its progress to a JSON file via the :class:`Storage`
+utility. Tasks, supervisor decisions and the messages exchanged with the
+manager are written after every update. To resume a previous run, provide the
+same storage file when constructing the manager and load the saved data:
+
+```python
+from core import Storage
+storage = Storage("state.json")
+tasks, agents, decisions, messages = storage.load()
+```
+
+This allows interrupted projects to continue without losing context from the
+earlier conversation.

--- a/src/core/storage.py
+++ b/src/core/storage.py
@@ -1,10 +1,12 @@
-"""Persistence utilities for tasks and agent states."""
+"""Persistence utilities for tasks, decisions and messages."""
 
 from __future__ import annotations
 
 import json
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
+
+from agents.message import Message
 
 from .task import Task, TaskStatus
 
@@ -30,24 +32,79 @@ def task_from_dict(data: Dict[str, Any]) -> Task:
 
 
 class Storage:
-    """Simple JSON based storage for tasks and agent states."""
+    """Simple JSON based storage for tasks and agent communication."""
 
     def __init__(self, path: str | Path) -> None:
         self.path = Path(path)
 
-    def save(self, tasks: List[Task], agent_states: Dict[str, Dict[str, Any]]) -> None:
-        """Persist ``tasks`` and ``agent_states`` to disk."""
+    # ------------------------------------------------------------------
+    def save(
+        self,
+        tasks: List[Task],
+        agent_states: Dict[str, Dict[str, Any]] | None = None,
+        decisions: List[str] | None = None,
+        messages: List[Message] | None = None,
+    ) -> None:
+        """Persist framework state to disk.
+
+        Parameters
+        ----------
+        tasks:
+            List of current tasks.
+        agent_states:
+            Optional mapping of agent specific state data.
+        decisions:
+            Decisions exchanged between supervisor and manager.
+        messages:
+            Messages exchanged between supervisor and manager.
+        """
+
+        def message_to_dict(message: Message) -> Dict[str, Any]:
+            metadata = message.metadata
+            if metadata and "tasks" in metadata:
+                metadata = dict(metadata)
+                metadata["tasks"] = [task_to_dict(t) for t in metadata["tasks"]]
+            return {
+                "sender": message.sender,
+                "content": message.content,
+                "metadata": metadata,
+            }
+
         data = {
             "tasks": [task_to_dict(t) for t in tasks],
-            "agents": agent_states,
+            "agents": agent_states or {},
+            "decisions": decisions or [],
+            "messages": [message_to_dict(m) for m in messages or []],
         }
         self.path.write_text(json.dumps(data, indent=2))
 
-    def load(self) -> Tuple[List[Task], Dict[str, Dict[str, Any]]]:
-        """Load tasks and agent states from disk."""
+    # ------------------------------------------------------------------
+    def load(
+        self,
+        ) -> Tuple[
+            List[Task],
+            Dict[str, Dict[str, Any]],
+            List[str],
+            List[Message],
+        ]:
+        """Load tasks, agent states, decisions and messages from disk."""
+
+        def message_from_dict(data: Dict[str, Any]) -> Message:
+            metadata = data.get("metadata")
+            if metadata and "tasks" in metadata:
+                metadata = dict(metadata)
+                metadata["tasks"] = [task_from_dict(t) for t in metadata["tasks"]]
+            return Message(
+                sender=data["sender"],
+                content=data["content"],
+                metadata=metadata,
+            )
+
         if not self.path.exists():
-            return [], {}
+            return [], {}, [], []
         raw = json.loads(self.path.read_text())
         tasks = [task_from_dict(t) for t in raw.get("tasks", [])]
         agents = raw.get("agents", {})
-        return tasks, agents
+        decisions = raw.get("decisions", [])
+        messages = [message_from_dict(m) for m in raw.get("messages", [])]
+        return tasks, agents, decisions, messages

--- a/tests/test_project_resume.py
+++ b/tests/test_project_resume.py
@@ -1,0 +1,54 @@
+import asyncio
+import pathlib
+import sys
+
+import pytest
+
+# Ensure src directory on path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from agents import Agent, Message
+from agents.manager import Manager
+from core import MessageBus, Storage, TaskStatus
+
+
+class EchoAgent(Agent):
+    """Agent that returns uppercase messages."""
+
+    def __init__(self, name: str, bus: MessageBus) -> None:
+        self.name = name
+        self.bus = bus
+        self.queue = bus.register(name)
+
+    def plan(self) -> Message:  # type: ignore[override]
+        return Message(sender=self.name, content="ready")
+
+    def act(self, message: Message) -> Message:  # type: ignore[override]
+        return Message(sender=self.name, content=message.content.upper(), metadata=message.metadata)
+
+    def observe(self, message: Message) -> None:  # type: ignore[override]
+        pass
+
+
+@pytest.mark.asyncio
+async def test_save_and_resume(tmp_path):
+    bus = MessageBus()
+    storage = Storage(tmp_path / "state.json")
+    worker = EchoAgent("worker", bus)
+    manager = Manager({"worker": worker}, bus=bus, storage=storage)
+
+    run_task = asyncio.create_task(manager.run("alpha."))
+    plan = await bus.recv_from_supervisor()
+    assert plan.content == "plan"
+    bus.send_to_supervisor(Message(sender="supervisor", content="approve"))
+    tasks = await run_task
+
+    assert tasks[0].status is TaskStatus.DONE
+    assert tasks[0].result == "ALPHA"
+
+    loaded_tasks, _, decisions, messages = storage.load()
+    assert loaded_tasks == tasks
+    assert decisions == ["approve"]
+    assert any(m.content == "progress" for m in messages)
+    # First message should be the plan sent to supervisor
+    assert messages[0].content == "plan"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -17,9 +17,11 @@ def test_save_and_load(tmp_path):
     agent_states = {"agent1": {"count": 3}, "agent2": {"status": "idle"}}
 
     storage.save(tasks, agent_states)
-    loaded_tasks, loaded_agents = storage.load()
+    loaded_tasks, loaded_agents, loaded_decisions, loaded_messages = storage.load()
 
     assert loaded_tasks == tasks
     assert loaded_agents == agent_states
+    assert loaded_decisions == []
+    assert loaded_messages == []
     assert loaded_tasks[0].status is TaskStatus.DONE
     assert loaded_tasks[1].status is TaskStatus.PENDING


### PR DESCRIPTION
## Summary
- extend storage to serialize tasks, decisions, and supervisor↔manager messages
- persist task updates from Manager using injected Storage instance
- document resuming workflows and add regression tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa46954cb88326afb6c6ff36f97328