### PR TITLE
docs: add supervisor schema and guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,28 @@ ollama-crewai-agents [-c config/agents.yaml] [--debug]
 
 The repository ships with a sample configuration file in `config/agents.yaml`.
 
+#### Superviseur ↔ Manager ↔ Agents
+
+```text
+Superviseur <-> Manager <-> Agents
+```
+
+Launch the orchestration from the command line:
+
+```bash
+ollama-crewai-agents -c config/agents.yaml
+```
+
+Example session:
+
+```text
+$ ollama-crewai-agents -c config/agents.yaml
+manager  | objective loaded
+planner  | plan feature
+developer| implement feature
+tester   | test feature
+```
+
 ### Agent configuration and workflow
 
 Agents are declared in a YAML or JSON file.  The manager loads this
@@ -137,6 +159,7 @@ overall workflow.
 
 - Accept command-line arguments for URL and character limit.
 - Integrate asynchronous fetching or caching mechanisms.
+- [Create custom agents](docs/extension.md).
 
 ## Contributing
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -39,6 +39,13 @@ AGENTS_CONFIG=config/agents.yaml AGENTS_DEBUG=1 ollama-crewai-agents
 3. Tasks are dispatched round-robin to the agents.
 4. Agents process tasks and report results back to the manager.
 
+## Supervision humaine
+
+Pendant l'exécution, un superviseur humain peut valider ou ajuster les
+plans proposés par le manager. Les messages saisis par le superviseur sont
+transmis au manager, qui les relaie ensuite aux agents pour guider la
+progression du projet.
+
 ## Logging
 
 The framework uses a structured logger configured via `core.logging`. Each
@@ -66,3 +73,6 @@ tasks, agents, decisions, messages = storage.load()
 
 This allows interrupted projects to continue without losing context from the
 earlier conversation.
+
+For instructions on creating vos propres agents personnalisés, consultez
+[le guide d'extension](extension.md).


### PR DESCRIPTION
## Summary
- illustrate Supervisor ↔ Manager ↔ Agents workflow with CLI example
- document human supervision in the tutorial
- link extension guide for custom agents

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa48bdfe2c832691ace3dfd3760c59