### PR TITLE
Add supervisor interface and manager error handling tests

### DIFF
--- a/tests/test_manager_error_handling.py
+++ b/tests/test_manager_error_handling.py
@@ -1,0 +1,47 @@
+import asyncio
+import pathlib
+import sys
+
+import pytest
+
+# Ensure src directory on path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from agents import Agent, Message
+from agents.manager import Manager
+from core import MessageBus, TaskStatus
+
+
+class ErrorAgent(Agent):
+    def __init__(self, name: str, bus: MessageBus) -> None:
+        self.name = name
+        self.bus = bus
+        self.queue = bus.register(name)
+
+    def plan(self) -> Message:  # type: ignore[override]
+        return Message(sender=self.name, content="ready")
+
+    def act(self, message: Message) -> Message:  # type: ignore[override]
+        raise RuntimeError("boom")
+
+    def observe(self, message: Message) -> None:  # type: ignore[override]
+        pass
+
+
+@pytest.mark.asyncio
+async def test_error_propagates_to_supervisor() -> None:
+    bus = MessageBus()
+    worker = ErrorAgent("worker", bus)
+    manager = Manager({"worker": worker}, bus=bus)
+
+    run_task = asyncio.create_task(manager.run("task."))
+    plan = await asyncio.wait_for(bus.recv_from_supervisor(), timeout=1)
+    assert plan.content == "plan"
+    bus.send_to_supervisor(Message(sender="supervisor", content="approve"))
+
+    progress = await asyncio.wait_for(bus.recv_from_supervisor(), timeout=1)
+    assert progress.content == "progress"
+    tasks = progress.metadata["tasks"]
+    assert tasks[0].status is TaskStatus.FAILED
+
+    await run_task

--- a/tests/test_supervisor_interface.py
+++ b/tests/test_supervisor_interface.py
@@ -1,0 +1,33 @@
+import asyncio
+import pathlib
+import sys
+
+import pytest
+
+# Ensure src directory on path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from agents.manager import Manager
+from core import MessageBus, TaskStatus
+from cli import run_supervised
+from supervisor import interface
+
+
+@pytest.mark.asyncio
+async def test_cancel_command(monkeypatch) -> None:
+    bus = MessageBus()
+    manager = Manager({}, bus=bus)
+    monkeypatch.setattr(interface, "read_user_command", lambda: "cancel")
+    monkeypatch.setattr(interface, "display_progress", lambda tasks: None)
+    tasks = await run_supervised(manager, "do something.")
+    assert all(t.status is TaskStatus.PENDING for t in tasks)
+
+
+@pytest.mark.asyncio
+async def test_unknown_command(monkeypatch) -> None:
+    bus = MessageBus()
+    manager = Manager({}, bus=bus)
+    monkeypatch.setattr(interface, "read_user_command", lambda: "foobar")
+    monkeypatch.setattr(interface, "display_progress", lambda tasks: None)
+    tasks = await run_supervised(manager, "another task.")
+    assert all(t.status is TaskStatus.PENDING for t in tasks)


### PR DESCRIPTION
## Summary
- ensure supervisor interface handles cancellation and unknown commands
- propagate worker errors to supervisor and queue
- test manager error handling and invalid user inputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa9ee547948326b8832ba0ca3b66b4