### PR TITLE
Add config schema and integrate with CLI

### DIFF
--- a/config/supervised_example.yaml
+++ b/config/supervised_example.yaml
@@ -1,0 +1,24 @@
+objective: "Plan. Code. Test."
+policies:
+  allowed_commands: [plan, code, test]
+  network_access: false
+storage:
+  path: state.json
+supervision:
+  enabled: true
+agents:
+  planner:
+    model: gpt-4
+    tools: []
+  developer:
+    model: gpt-4
+    tools: [filesystem]
+  tester:
+    model: gpt-4
+    tools: [pytest]
+  writer:
+    model: gpt-4
+    tools: [filesystem]
+  researcher:
+    model: gpt-4
+    tools: [aiohttp]

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+"""Pydantic models for validating application configuration."""
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+import json
+import yaml
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+
+class PoliciesConfig(BaseModel):
+    """Configuration for command and network policies."""
+
+    allowed_commands: List[str] | None = None
+    network_access: bool | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class StorageConfig(BaseModel):
+    """Configuration of persistence storage."""
+
+    path: str
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class SupervisionConfig(BaseModel):
+    """Options for supervisor interaction."""
+
+    enabled: bool = True
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ConfigModel(BaseModel):
+    """Top-level application configuration."""
+
+    objective: str = ""
+    agents: Dict[str, Dict[str, Any]]
+    policies: PoliciesConfig = PoliciesConfig()
+    storage: StorageConfig | None = None
+    supervision: SupervisionConfig = SupervisionConfig()
+
+    model_config = ConfigDict(extra="forbid")
+
+
+def load_config(path: Path) -> ConfigModel:
+    """Load and validate a YAML or JSON configuration file."""
+
+    text = path.read_text(encoding="utf-8")
+    if path.suffix in {".yaml", ".yml"}:
+        raw = yaml.safe_load(text)  # type: ignore[assignment]
+    elif path.suffix == ".json":
+        raw = json.loads(text)
+    else:
+        raise ValueError(f"Unsupported config format: {path.suffix}")
+
+    try:
+        return ConfigModel.model_validate(raw)
+    except ValidationError as exc:  # pragma: no cover - exercised in tests
+        errors = "; ".join(
+            f"{'.'.join(str(p) for p in err['loc'])}: {err['msg']}" for err in exc.errors()
+        )
+        raise ValueError(f"Invalid configuration: {errors}") from exc

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,7 @@ def test_cli_load_and_run(tmp_path):
     manager = cli.build_manager(cfg)
 
     async def orchestrate() -> list:
-        run_task = asyncio.create_task(manager.run(cfg["objective"]))
+        run_task = asyncio.create_task(manager.run(cfg.objective))
         plan = await asyncio.wait_for(manager.bus.recv_from_supervisor(), timeout=1)
         assert plan.content == "plan"
         manager.bus.send_to_supervisor(Message(sender="supervisor", content="approve"))

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -1,0 +1,33 @@
+import pathlib
+import sys
+
+import pytest
+
+# Ensure src directory on path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from config.schema import load_config, ConfigModel
+
+
+def test_valid_config(tmp_path):
+    cfg_file = tmp_path / "cfg.yaml"
+    cfg_file.write_text(
+        "objective: 'alpha.'\n"
+        "agents:\n  planner: {}\n"
+        "policies:\n  allowed_commands: [alpha]\n  network_access: true\n"
+        "storage:\n  path: state.json\n"
+        "supervision:\n  enabled: true\n"
+    )
+    cfg = load_config(cfg_file)
+    assert isinstance(cfg, ConfigModel)
+    assert cfg.policies.allowed_commands == ["alpha"]
+    assert cfg.storage.path == "state.json"
+    assert cfg.supervision.enabled is True
+
+
+def test_invalid_agent_config(tmp_path):
+    cfg_file = tmp_path / "cfg.yaml"
+    cfg_file.write_text("agents:\n  planner: 'oops'\n")
+    with pytest.raises(ValueError) as excinfo:
+        load_config(cfg_file)
+    assert "agents.planner" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- add Pydantic configuration schema covering agents, policies, storage, and supervision
- update CLI to use new schema, configure policies/storage, and support basic mode
- provide supervised example config and validation tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aaa517c28883268a1e7bb56eae75b8