### PR TITLE
Enable async agents using aiohttp and to_thread

### DIFF
--- a/src/agents/base.py
+++ b/src/agents/base.py
@@ -71,7 +71,10 @@ class Agent(ABC):
             response = self.act(message)
             if inspect.isawaitable(response):
                 response = await response
-            self.observe(response)
+
+            observation = self.observe(response)
+            if inspect.isawaitable(observation):
+                await observation
 
             metadata: dict[str, object] = {}
             if message.metadata:

--- a/src/agents/researcher.py
+++ b/src/agents/researcher.py
@@ -15,7 +15,11 @@ from .message import Message
 
 @dataclass
 class ResearcherAgent(Agent):
-    """Agent that fetches information from the web using ``aiohttp``."""
+    """Agent that fetches information from the web using ``aiohttp``.
+
+    The :meth:`act` method performs an asynchronous HTTP GET request and
+    returns the first 200 characters of the response body.
+    """
     model: str = "gpt-4"
     capabilities: list[str] = field(default_factory=lambda: ["research", "web-fetch"])
     tools: list[str] = field(default_factory=lambda: ["aiohttp"])

--- a/src/agents/tester.py
+++ b/src/agents/tester.py
@@ -15,7 +15,7 @@ from .message import Message
 
 @dataclass
 class TesterAgent(Agent):
-    """Agent that runs pytest and returns the results."""
+    """Agent that runs pytest in a worker thread and returns the results."""
     __test__ = False  # prevent pytest from treating this as a test class
     model: str = "gpt-4"
     capabilities: list[str] = field(default_factory=lambda: ["testing"])

--- a/tests/test_researcher_agent.py
+++ b/tests/test_researcher_agent.py
@@ -1,6 +1,5 @@
 import pathlib
 import sys
-import requests
 import inspect
 import pytest
 
@@ -12,10 +11,8 @@ from agents.researcher import ResearcherAgent
 
 
 @pytest.mark.asyncio
-async def test_researcher_act_async(monkeypatch, requests_mock):
-    """ResearcherAgent.act should fetch data using a mocked HTTP response."""
-
-    requests_mock.get("http://example.com", text="dummy response")
+async def test_researcher_act_async(monkeypatch):
+    """ResearcherAgent.act should fetch data using a mocked aiohttp response."""
 
     class DummyResponse:
         def __init__(self, text: str) -> None:
@@ -41,8 +38,7 @@ async def test_researcher_act_async(monkeypatch, requests_mock):
             return False
 
         def get(self, url):
-            response = requests.get(url)
-            return DummyResponse(response.text)
+            return DummyResponse("dummy response")
 
     monkeypatch.setattr(
         "agents.researcher.aiohttp.ClientSession", lambda *args, **kwargs: DummySession()

--- a/tests/test_tester_agent.py
+++ b/tests/test_tester_agent.py
@@ -18,13 +18,22 @@ async def test_tester_act_async(monkeypatch):
         class Result:
             stdout = "ok"
             stderr = ""
+
         return Result()
 
+    called: dict[str, object] = {}
+
+    async def fake_to_thread(func, *args, **kwargs):
+        called["func"] = func
+        return func(*args, **kwargs)
+
     monkeypatch.setattr("agents.tester.subprocess.run", fake_run)
+    monkeypatch.setattr("agents.tester.asyncio.to_thread", fake_to_thread)
 
     agent = TesterAgent()
     assert inspect.iscoroutinefunction(agent.act)
     response = await agent.act(Message(sender="manager", content="echo hi"))
+    assert called["func"] is fake_run
     assert response.content == "success"
     assert response.metadata["output"] == "ok"
     assert agent.last_result == "ok"


### PR DESCRIPTION
## Summary
- make ResearcherAgent perform asynchronous HTTP requests with aiohttp
- run TesterAgent's pytest invocations in a background thread
- allow Agent.handle to await coroutine observations
- add tests exercising async researcher and tester agents

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aebb2591548326a05c7a31742af67b