### PR TITLE
Remove unused OpenAI dependencies

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,6 +11,8 @@ These steps describe how to set up the project and install its dependencies.
    ```bash
    pip install -r requirements.txt
    ```
+   The project relies solely on local components; no OpenAI or LiteLLM
+   API key is needed.
 3. Run the application:
    ```bash
    python src/main.py

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Ollama_CrewAi illustre une architecture **Manager ↔ Agents** minimaliste. Le m
    pip install .
    ```
 
+   Le projet ne dépend d'aucun fournisseur LLM externe ; aucune clé API
+   OpenAI ou LiteLLM n'est nécessaire.
+
 2. **Lancer le scénario fourni**
 
    ```bash
@@ -52,11 +55,14 @@ Follow these steps to set up the project and run the test suite:
 
 3. **Install the package**
 
-   To install the CLI and its dependencies:
+To install the CLI and its dependencies:
 
    ```bash
    pip install .
    ```
+
+   No external LLM providers are included, so no OpenAI or LiteLLM API
+   key is required.
 
    Alternatively, install the dependencies directly:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,10 @@ version = "0.1.0"
 dependencies = [
     "requests>=2.31.0",
     "pyyaml>=6.0",
-    # Agent framework and LLM integrations
+    # Agent framework dependencies
     "crewai",
     "pydantic",
     "aiohttp",
-    "openai",
-    "litellm",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,7 @@ requests==2.31.0
 pytest-asyncio
 PyYAML>=6.0
 requests-mock
-# Additional dependencies for agent framework and LLM integrations
+# Additional dependencies for agent framework
 crewai
 pydantic
 aiohttp
-openai
-litellm


### PR DESCRIPTION
## Summary
- remove OpenAI and LiteLLM from requirements and project dependencies
- document that no external LLM API key is needed for installation

## Testing
- `pip install -r requirements.txt pytest requests-mock pytest-asyncio`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aec8761ac48326a3412849d1612993