### PR TITLE
feat: persist manager tasks across runs

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -58,21 +58,23 @@ INFO|developer|1|completed
 The logger is automatically injected into all agents and the manager, so
 logs are emitted during task processing without extra setup.
 
-## Resuming a workflow
+## Resuming and stopping a workflow
 
 The manager can persist its progress to a JSON file via the :class:`Storage`
-utility. Tasks, supervisor decisions and the messages exchanged with the
-manager are written after every update. To resume a previous run, provide the
-same storage file when constructing the manager and load the saved data:
+utility. When a storage backend is supplied, the manager loads any previously
+saved tasks, supervisor decisions and messages at startup. The state is
+serialised after every update, allowing the process to be stopped at any time
+and later resumed by constructing the manager with the same storage file.
 
 ```python
 from core import Storage
 storage = Storage("state.json")
-tasks, agents, decisions, messages = storage.load()
+manager = Manager(agents, bus=bus, storage=storage)
+await manager.run("objective")
 ```
 
-This allows interrupted projects to continue without losing context from the
-earlier conversation.
+This flow makes it easy to interrupt a project and continue later without
+losing context from the earlier conversation.
 
 For instructions on creating vos propres agents personnalisés, consultez
 [le guide d'extension](extension.md).

--- a/tests/test_manager_storage.py
+++ b/tests/test_manager_storage.py
@@ -1,0 +1,63 @@
+import asyncio
+import pathlib
+import sys
+
+import pytest
+
+# Ensure src directory on path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from agents import Agent, Message
+from agents.manager import Manager
+from core import MessageBus, Storage, Task, TaskStatus
+
+
+class EchoAgent(Agent):
+    """Agent that returns uppercase messages and records observations."""
+
+    def __init__(self, name: str, bus: MessageBus) -> None:
+        self.name = name
+        self.bus = bus
+        self.queue = bus.register(name)
+        self.observed: list[Message] = []
+
+    def plan(self) -> Message:  # type: ignore[override]
+        return Message(sender=self.name, content="ready")
+
+    def act(self, message: Message) -> Message:  # type: ignore[override]
+        self.observed.append(message)
+        return Message(sender=self.name, content=message.content.upper(), metadata=message.metadata)
+
+    def observe(self, message: Message) -> None:  # type: ignore[override]
+        self.observed.append(message)
+
+
+@pytest.mark.asyncio
+async def test_resume_tasks_from_storage(tmp_path):
+    bus = MessageBus()
+    storage = Storage(tmp_path / "state.json")
+    worker = EchoAgent("worker", bus)
+
+    tasks = [
+        Task(id=1, description="alpha", status=TaskStatus.DONE, result="ALPHA"),
+        Task(id=2, description="beta"),
+    ]
+    storage.save(tasks)
+
+    manager = Manager({"worker": worker}, bus=bus, storage=storage)
+    assert manager._tasks == tasks
+
+    run_task = asyncio.create_task(manager.run("resume"))
+    # No approval needed; manager immediately dispatches pending tasks
+    finished_tasks = await run_task
+
+    assert finished_tasks[0].result == "ALPHA"
+    assert finished_tasks[0].status is TaskStatus.DONE
+    assert finished_tasks[1].result == "BETA"
+    assert finished_tasks[1].status is TaskStatus.DONE
+    # Only the pending task was dispatched
+    assert worker.observed[0].content == "beta"
+    assert all(m.content != "alpha" for m in worker.observed)
+
+    reloaded, _, _, _ = storage.load()
+    assert reloaded == finished_tasks


### PR DESCRIPTION
## Summary
- allow `Manager` to accept an optional `Storage` and load persisted tasks, decisions and messages on startup
- skip completed tasks and resume pending ones while serialising state after each update
- document workflow stop/resume and add regression test for storage-based resumption

## Testing
- `pytest tests/test_manager_storage.py -q`
- `pytest tests/test_project_resume.py tests/test_manager_agent.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aecbd7a5d88326b302c44144d30875