### PR TITLE
Abort run when reply lacks task id

### DIFF
--- a/src/agents/manager.py
+++ b/src/agents/manager.py
@@ -209,6 +209,10 @@ class Manager(Agent):
                 else:
                     if msg.sender != "user":
                         self.observe(msg)
+                        if not msg.metadata or "task_id" not in msg.metadata:
+                            self.logger.warning("invalid_message", extra={"sender": msg.sender})
+                            self.queue.task_done()
+                            break
                         remaining -= 1
                     self.queue.task_done()
         finally:


### PR DESCRIPTION
## Summary
- stop `Manager.run` loop when a reply is missing metadata or `task_id`
- add regression test ensuring invalid replies leave tasks in progress

## Testing
- `pytest tests/test_project_workflow.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aed34658d88326b00400dd788d6260