### PR TITLE
docs: add editable install instructions and CLI test

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,7 +13,17 @@ These steps describe how to set up the project and install its dependencies.
    ```
    The project relies solely on local components; no OpenAI or LiteLLM
    API key is needed.
-3. Run the application:
+3. Make the command-line scripts available by installing the package:
+   ```bash
+   pip install -e .
+   # or
+   pipx install .
+   ```
+   A quick test ensures everything is wired up:
+   ```bash
+   ollama-crewai-agents -h
+   ```
+4. Run the application:
    ```bash
    python src/main.py
    ```

--- a/README.md
+++ b/README.md
@@ -9,11 +9,19 @@ Ollama_CrewAi illustre une architecture **Manager ↔ Agents** minimaliste. Le m
    ```bash
    git clone <repository-url>
    cd Ollama_CrewAi
-   pip install .
+   pip install -e .
+   # or
+   pipx install .
    ```
 
    Le projet ne dépend d'aucun fournisseur LLM externe ; aucune clé API
    OpenAI ou LiteLLM n'est nécessaire.
+
+   Vérifiez l'installation avec :
+
+   ```bash
+   ollama-crewai-agents -h
+   ```
 
 2. **Lancer le scénario fourni**
 
@@ -58,11 +66,19 @@ Follow these steps to set up the project and run the test suite:
 To install the CLI and its dependencies:
 
    ```bash
-   pip install .
+   pip install -e .
+   # or
+   pipx install .
    ```
 
    No external LLM providers are included, so no OpenAI or LiteLLM API
    key is required.
+
+   Quick test:
+
+   ```bash
+   ollama-crewai-agents -h
+   ```
 
    Alternatively, install the dependencies directly:
 


### PR DESCRIPTION
## Summary
- document editable/pipx installation to expose CLI scripts
- suggest quick `ollama-crewai-agents -h` check after installing

## Testing
- `ollama-crewai-agents -h`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aed51da1148326ad8648fe9d221c15