### PR TITLE
feat: add trail training website config

### DIFF
--- a/config/agents.yaml
+++ b/config/agents.yaml
@@ -1,17 +1,17 @@
 objective: "Plan. Implement. Test."
 agents:
   planner:
-    model: gpt-4
+    model: llama3
     tools: []
   developer:
-    model: gpt-4
+    model: codellama
     tools: [filesystem]
   writer:
-    model: gpt-4
+    model: llama3
     tools: [filesystem]
   tester:
-    model: gpt-4
+    model: llama3
     tools: [pytest]
   researcher:
-    model: gpt-4
+    model: mistral
     tools: [aiohttp]

--- a/config/trail_training_site.yaml
+++ b/config/trail_training_site.yaml
@@ -1,6 +1,6 @@
-objective: "Plan. Code. Test."
+objective: "Créer un site web simple présentant les stratégies d'entraînement en trail (course à pied, trail, renforcement, yoga, etc.) et fournir une critique de chaque étape."
 policies:
-  allowed_commands: [plan, code, test]
+  allowed_commands: [plan, code, write, test, research]
   network_access: false
 storage:
   path: state.json
@@ -13,12 +13,12 @@ agents:
   developer:
     model: codellama
     tools: [filesystem]
-  tester:
-    model: llama3
-    tools: [pytest]
   writer:
     model: llama3
     tools: [filesystem]
+  tester:
+    model: llama3
+    tools: [pytest]
   researcher:
     model: mistral
     tools: [aiohttp]

--- a/src/agents/developer.py
+++ b/src/agents/developer.py
@@ -16,7 +16,7 @@ from .message import Message
 @dataclass
 class DeveloperAgent(Agent):
     """Agent that writes provided code snippets to the filesystem."""
-    model: str = "gpt-4"
+    model: str = "codellama"
     capabilities: list[str] = field(
         default_factory=lambda: ["coding", "file-writing", "file-reading"]
     )

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -16,7 +16,7 @@ from .message import Message
 @dataclass
 class PlannerAgent(Agent):
     """Agent that decomposes objectives into smaller tasks."""
-    model: str = "gpt-4"
+    model: str = "llama3"
     capabilities: list[str] = field(default_factory=lambda: ["planning", "decomposition"])
     tools: list[str] = field(default_factory=list)
     tasks: List[str] = field(default_factory=list)

--- a/src/agents/researcher.py
+++ b/src/agents/researcher.py
@@ -20,7 +20,7 @@ class ResearcherAgent(Agent):
     The :meth:`act` method performs an asynchronous HTTP GET request and
     returns the first 200 characters of the response body.
     """
-    model: str = "gpt-4"
+    model: str = "mistral"
     capabilities: list[str] = field(default_factory=lambda: ["research", "web-fetch"])
     tools: list[str] = field(default_factory=lambda: ["aiohttp"])
     last_response: str | None = None

--- a/src/agents/tester.py
+++ b/src/agents/tester.py
@@ -17,7 +17,7 @@ from .message import Message
 class TesterAgent(Agent):
     """Agent that runs pytest in a worker thread and returns the results."""
     __test__ = False  # prevent pytest from treating this as a test class
-    model: str = "gpt-4"
+    model: str = "llama3"
     capabilities: list[str] = field(default_factory=lambda: ["testing"])
     tools: list[str] = field(default_factory=lambda: ["pytest"])
     last_result: str | None = None

--- a/src/agents/writer.py
+++ b/src/agents/writer.py
@@ -17,7 +17,7 @@ from .message import Message
 @dataclass
 class WriterAgent(Agent):
     """Agent that writes documentation files to the filesystem."""
-    model: str = "gpt-4"
+    model: str = "llama3"
     capabilities: list[str] = field(default_factory=lambda: ["documentation"])
     tools: list[str] = field(default_factory=lambda: ["filesystem"])
     documents: Dict[Path, str] = field(default_factory=dict)


### PR DESCRIPTION
## Summary
- add configuration to build a training strategies website with supervision enabled and all agents
- configure agents to use relevant Ollama models instead of GPT-4

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af5318e59c83268a14ee4a75e4a8b0