### PR TITLE
Integrate Ollama LLM into agents and tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "openai",
     "litellm",
     "ollama",
+    "langchain-ollama",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ aiohttp
 openai
 litellm
 ollama
+langchain-ollama

--- a/src/agents/developer.py
+++ b/src/agents/developer.py
@@ -1,49 +1,63 @@
-"""Developer agent responsible for basic file interactions."""
+"""Developer agent responsible for generating and saving code."""
 
 from __future__ import annotations
 
 from pathlib import Path
 from typing import Optional, Union
 
+from langchain_ollama import OllamaLLM
+
 from .base import Agent
 
 
 class DeveloperAgent(Agent):
-    """Agent that writes provided code snippets to the filesystem."""
-
-    role: str = "Developer"
-    goal: str = "Write and read files as requested"
-    backstory: str = "An AI developer assisting with code tasks."
-    verbose: bool = False
-    allow_delegation: bool = False
-    llm: str = "codellama"
+    """Agent that uses an LLM to generate code and optionally save it."""
 
     last_written: Optional[Path] = None
+
+    def __init__(
+        self,
+        *,
+        role: str = "Developer",
+        goal: str = "Write and read files as requested",
+        backstory: str = "An AI developer assisting with code tasks.",
+        model: str = "codellama",
+        llm: OllamaLLM | None = None,
+        verbose: bool = False,
+        allow_delegation: bool = False,
+    ) -> None:
+        super().__init__(
+            role=role,
+            goal=goal,
+            backstory=backstory,
+            llm=llm or OllamaLLM(model=model),
+            verbose=verbose,
+            allow_delegation=allow_delegation,
+        )
+        self.last_written = None
 
     def plan(self) -> str:
         return "ready"
 
     def act(
         self,
+        prompt: str,
         *,
         path: Union[str, Path] | None = None,
-        code: str = "",
-        read: Union[str, Path] | None = None,
     ) -> str:
+        """Generate code from ``prompt`` and optionally write to ``path``."""
+        code = self.llm.invoke(prompt)
         if path is not None:
             p = Path(path)
             p.parent.mkdir(parents=True, exist_ok=True)
             p.write_text(code)
             self.last_written = p
-            return f"wrote {p}"
-        if read is not None:
-            p = Path(read)
-            try:
-                return p.read_text()
-            except FileNotFoundError:
-                return "file not found"
-        return "no action"
+        return code
 
     def observe(self, result: str) -> None:
-        if result.startswith("wrote "):
-            self.last_written = Path(result.split(" ", 1)[1])
+        try:
+            p = Path(result)
+        except TypeError:  # pragma: no cover - non-path input
+            return
+        if p.exists():
+            self.last_written = p

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -4,23 +4,40 @@ from __future__ import annotations
 
 from typing import List
 
+from langchain_ollama import OllamaLLM
+
 from .base import Agent
 
 
 class PlannerAgent(Agent):
-    """Agent that decomposes objectives into smaller tasks."""
-
-    role: str = "Planner"
-    goal: str = "Break down objectives into tasks"
-    backstory: str = "A strategic planner that organises work."
-    verbose: bool = False
-    allow_delegation: bool = False
-    llm: str = "llama3"
+    """Agent that uses an LLM to break objectives into tasks."""
 
     tasks: List[str] = []
 
+    def __init__(
+        self,
+        *,
+        role: str = "Planner",
+        goal: str = "Break down objectives into tasks",
+        backstory: str = "A strategic planner that organises work.",
+        model: str = "llama3",
+        llm: OllamaLLM | None = None,
+        verbose: bool = False,
+        allow_delegation: bool = False,
+    ) -> None:
+        super().__init__(
+            role=role,
+            goal=goal,
+            backstory=backstory,
+            llm=llm or OllamaLLM(model=model),
+            verbose=verbose,
+            allow_delegation=allow_delegation,
+        )
+        self.tasks = []
+
     def plan(self, objective: str) -> List[str]:
-        self.tasks = [t.strip() for t in objective.split(".") if t.strip()]
+        plan_text = self.llm.invoke(objective)
+        self.tasks = [t.strip().lstrip("-0123456789. ") for t in plan_text.splitlines() if t.strip()]
         return self.tasks
 
     def act(self, objective: str) -> List[str]:

--- a/src/agents/researcher.py
+++ b/src/agents/researcher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Optional
 import aiohttp
+from langchain_ollama import OllamaLLM
 
 from .base import Agent
 
@@ -11,14 +12,28 @@ from .base import Agent
 class ResearcherAgent(Agent):
     """Agent that performs simple HTTP GET requests."""
 
-    role: str = "Researcher"
-    goal: str = "Gather information from the internet"
-    backstory: str = "An AI that searches the web for relevant data."
-    verbose: bool = False
-    allow_delegation: bool = False
-    llm: str = "mistral"
-
     last_response: Optional[str] = None
+
+    def __init__(
+        self,
+        *,
+        role: str = "Researcher",
+        goal: str = "Gather information from the internet",
+        backstory: str = "An AI that searches the web for relevant data.",
+        model: str = "mistral",
+        llm: OllamaLLM | None = None,
+        verbose: bool = False,
+        allow_delegation: bool = False,
+    ) -> None:
+        super().__init__(
+            role=role,
+            goal=goal,
+            backstory=backstory,
+            llm=llm or OllamaLLM(model=model),
+            verbose=verbose,
+            allow_delegation=allow_delegation,
+        )
+        self.last_response = None
 
     def plan(self) -> str:
         return "ready"

--- a/src/agents/tester.py
+++ b/src/agents/tester.py
@@ -6,6 +6,8 @@ import subprocess
 import asyncio
 from typing import Optional
 
+from langchain_ollama import OllamaLLM
+
 from .base import Agent
 
 
@@ -13,14 +15,28 @@ class TesterAgent(Agent):
     """Agent that runs shell commands such as pytest."""
 
     __test__ = False  # prevent pytest from collecting as a test class
-    role: str = "Tester"
-    goal: str = "Verify code correctness by running tests"
-    backstory: str = "An AI tasked with executing test commands."
-    verbose: bool = False
-    allow_delegation: bool = False
-    llm: str = "llama3"
-
     last_result: Optional[str] = None
+
+    def __init__(
+        self,
+        *,
+        role: str = "Tester",
+        goal: str = "Verify code correctness by running tests",
+        backstory: str = "An AI tasked with executing test commands.",
+        model: str = "llama3",
+        llm: OllamaLLM | None = None,
+        verbose: bool = False,
+        allow_delegation: bool = False,
+    ) -> None:
+        super().__init__(
+            role=role,
+            goal=goal,
+            backstory=backstory,
+            llm=llm or OllamaLLM(model=model),
+            verbose=verbose,
+            allow_delegation=allow_delegation,
+        )
+        self.last_result = None
 
     def plan(self) -> str:
         return "ready"

--- a/src/agents/writer.py
+++ b/src/agents/writer.py
@@ -5,37 +5,57 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Dict, Union
 
+from langchain_ollama import OllamaLLM
+
 from .base import Agent
 
 
 class WriterAgent(Agent):
-    """Agent that writes documentation files to the filesystem."""
-
-    role: str = "Writer"
-    goal: str = "Produce documentation files"
-    backstory: str = "An AI writer creating project docs."
-    verbose: bool = False
-    allow_delegation: bool = False
-    llm: str = "llama3"
+    """Agent that uses an LLM to generate documentation and save it."""
 
     documents: Dict[Path, str] = {}
+
+    def __init__(
+        self,
+        *,
+        role: str = "Writer",
+        goal: str = "Produce documentation files",
+        backstory: str = "An AI writer creating project docs.",
+        model: str = "llama3",
+        llm: OllamaLLM | None = None,
+        verbose: bool = False,
+        allow_delegation: bool = False,
+    ) -> None:
+        super().__init__(
+            role=role,
+            goal=goal,
+            backstory=backstory,
+            llm=llm or OllamaLLM(model=model),
+            verbose=verbose,
+            allow_delegation=allow_delegation,
+        )
+        self.documents = {}
 
     def plan(self) -> str:
         return "ready"
 
-    def act(self, *, path: Union[str, Path] | None = None, text: str = "") -> str:
-        if path is None:
-            return "no document"
-        p = Path(path)
-        p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text(text)
-        self.documents[p] = text
-        return f"wrote {p}"
+    def act(
+        self,
+        prompt: str,
+        *,
+        path: Union[str, Path] | None = None,
+    ) -> str:
+        text = self.llm.invoke(prompt)
+        if path is not None:
+            p = Path(path)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(text)
+            self.documents[p] = text
+        return text
 
-    def observe(self, result: str) -> None:
-        if result.startswith("wrote "):
-            p = Path(result.split(" ", 1)[1])
-            try:
-                self.documents[p] = p.read_text()
-            except FileNotFoundError:  # pragma: no cover - file missing
-                self.documents[p] = ""
+    def observe(self, path: Union[str, Path]) -> None:
+        p = Path(path)
+        try:
+            self.documents[p] = p.read_text()
+        except FileNotFoundError:  # pragma: no cover - file missing
+            self.documents[p] = ""

--- a/tests/test_developer_agent.py
+++ b/tests/test_developer_agent.py
@@ -7,14 +7,23 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 from agents.developer import DeveloperAgent
 
 
-def test_developer_writes_code(tmp_path):
+class StubLLM:
+    def __init__(self, output: str) -> None:
+        self.output = output
+        self.last_prompt: str | None = None
+
+    def invoke(self, prompt: str) -> str:
+        self.last_prompt = prompt
+        return self.output
+
+
+def test_developer_generates_code(tmp_path):
     developer = DeveloperAgent()
+    developer.llm = StubLLM("print('hi')")
     target = tmp_path / "example.py"
 
-    response = developer.act(path=target, code="print('hi')")
+    code = developer.act("Write a hello program", path=target)
 
+    assert code == "print('hi')"
     assert target.read_text() == "print('hi')"
-    assert response == f"wrote {target}"
-
-    developer.observe(response)
     assert developer.last_written == target

--- a/tests/test_planner_agent.py
+++ b/tests/test_planner_agent.py
@@ -7,9 +7,20 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 from agents.planner import PlannerAgent
 
 
+class StubLLM:
+    def __init__(self, output: str) -> None:
+        self.output = output
+        self.last_prompt: str | None = None
+
+    def invoke(self, prompt: str) -> str:
+        self.last_prompt = prompt
+        return self.output
+
+
 def test_planner_decomposes_tasks():
     planner = PlannerAgent()
-    response = planner.act("alpha. beta.")
+    planner.llm = StubLLM("1. alpha\n2. beta")
+    response = planner.act("plan something")
     assert response == ["alpha", "beta"]
     planner.observe(response)
     assert planner.tasks == ["alpha", "beta"]

--- a/tests/test_writer_agent.py
+++ b/tests/test_writer_agent.py
@@ -7,25 +7,37 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 from agents.writer import WriterAgent
 
 
+class StubLLM:
+    def __init__(self, output: str) -> None:
+        self.output = output
+        self.last_prompt: str | None = None
+
+    def invoke(self, prompt: str) -> str:
+        self.last_prompt = prompt
+        return self.output
+
+
 def test_writer_act_creates_file_and_updates_documents(tmp_path):
-    """WriterAgent.act should write file and store it in documents dict."""
+    """WriterAgent.act should generate file via LLM and store it."""
     agent = WriterAgent()
+    agent.llm = StubLLM("hello")
     file_path = tmp_path / "docs" / "output.txt"
 
-    response = agent.act(path=file_path, text="hello")
+    text = agent.act("Write greeting", path=file_path)
 
     assert file_path.read_text() == "hello"
     assert agent.documents[file_path] == "hello"
-    assert response == f"wrote {file_path}"
+    assert text == "hello"
 
 
 def test_writer_observe_updates_documents(tmp_path):
     """observe should record paths mentioned in messages."""
     agent = WriterAgent()
+    agent.llm = StubLLM("unused")
     file_path = tmp_path / "docs" / "extra.txt"
     file_path.parent.mkdir(parents=True, exist_ok=True)
     file_path.write_text("more text")
 
-    agent.observe(f"wrote {file_path}")
+    agent.observe(file_path)
 
     assert agent.documents[file_path] == "more text"


### PR DESCRIPTION
## Summary
- Instantiate `OllamaLLM` in all agents and expose configurable `role`, `goal`, and `backstory` parameters
- Refactor agent actions (developer, planner, writer) to rely on LLM generation
- Add `langchain-ollama` dependency and update tests to validate LLM usage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af6c6f37808326b9c746a7802bc3df