### PR TITLE
feat: support detailed agent config

### DIFF
--- a/config/agents.yaml
+++ b/config/agents.yaml
@@ -1,17 +1,47 @@
 objective: "Plan. Implement. Test."
 agents:
   planner:
-    model: llama3
+    role: "Planner"
+    goal: "Break down objectives into tasks"
+    backstory: "A strategic planner that organises work."
+    llm:
+      model: llama3
+      base_url: "http://localhost:11434"
+      temperature: 0.0
     tools: []
   developer:
-    model: codellama
+    role: "Developer"
+    goal: "Write and read files as requested"
+    backstory: "An AI developer assisting with code tasks."
+    llm:
+      model: codellama
+      base_url: "http://localhost:11434"
+      temperature: 0.0
     tools: [filesystem]
   writer:
-    model: llama3
+    role: "Writer"
+    goal: "Produce documentation files"
+    backstory: "An AI writer creating project docs."
+    llm:
+      model: llama3
+      base_url: "http://localhost:11434"
+      temperature: 0.0
     tools: [filesystem]
   tester:
-    model: llama3
+    role: "Tester"
+    goal: "Verify code correctness by running tests"
+    backstory: "An AI tasked with executing test commands."
+    llm:
+      model: llama3
+      base_url: "http://localhost:11434"
+      temperature: 0.0
     tools: [pytest]
   researcher:
-    model: mistral
+    role: "Researcher"
+    goal: "Gather information from the internet"
+    backstory: "An AI that searches the web for relevant data."
+    llm:
+      model: mistral
+      base_url: "http://localhost:11434"
+      temperature: 0.0
     tools: [aiohttp]

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Dict, List
 
 import yaml
 from pydantic import BaseModel, ConfigDict, ValidationError
@@ -35,11 +35,33 @@ class SupervisionConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class LLMConfig(BaseModel):
+    """Configuration for an agent's language model."""
+
+    model: str
+    base_url: str | None = None
+    temperature: float | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class AgentConfig(BaseModel):
+    """Configuration for a single agent."""
+
+    role: str
+    goal: str
+    backstory: str
+    llm: LLMConfig
+    tools: List[str] | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
 class ConfigModel(BaseModel):
     """Top-level application configuration."""
 
     objective: str = ""
-    agents: Dict[str, Dict[str, Any]]
+    agents: Dict[str, AgentConfig]
     policies: PoliciesConfig = PoliciesConfig()
     storage: StorageConfig | None = None
     supervision: SupervisionConfig = SupervisionConfig()


### PR DESCRIPTION
## Summary
- expand agent configs to include role, goal, backstory, and llm settings
- validate new fields via pydantic schema
- pass llm parameters when constructing agents in CLI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af6ec2b3548326ad4dcdeff133c950